### PR TITLE
fixed bug causing incorrect date for sunset

### DIFF
--- a/lib/sun_times.ex
+++ b/lib/sun_times.ex
@@ -79,11 +79,13 @@ defmodule SunTimes do
 
         # T = H + RA - (0.06571 * t) - 6.622
         local_mean_time = suns_local_hour_hours + sun_right_ascension_hours - (0.06571 * approximate_time) - 6.622
+        local_mean_time = if event == :set, do: local_mean_time + 24, else: local_mean_time
 
         # UT = T - lngHour
         gmt_hours = local_mean_time - longitude_hour
-        gmt_hours = if gmt_hours > 24, do: gmt_hours - 24.0, else: gmt_hours
-        gmt_hours = if gmt_hours < 0, do: gmt_hours + 24.0, else: gmt_hours
+
+        {datetime, gmt_hours} = if gmt_hours > 24, do: {gmt_hours - 24.0, next_day(datetime)}, else: {gmt_hours, datetime}
+        {datetime, gmt_hours} = if gmt_hours < 0, do: {gmt_hours + 24.0, prev_day(datetime)}, else: {gmt_hours, datetime}
 
         hour = Float.floor(gmt_hours)
         hour_remainder = (gmt_hours - hour) * 60.0

--- a/test/sun_times_test.exs
+++ b/test/sun_times_test.exs
@@ -1,0 +1,37 @@
+ExUnit.start()
+
+defmodule SunTimesTest do
+  use ExUnit.Case
+
+  defp testDate(), do: DateTime.new!(~D[2022-05-26], ~T[00:00:00], "Etc/UTC")
+
+  describe "rise/3" do
+    test "offsets of minus 15 degrees should adjust sunrise by aprox 1 hour forward" do
+      assert SunTimes.rise(testDate(), 41.00, -70.0-15)
+      |> DateTime.diff(SunTimes.rise(testDate(), 41.00, -70.0)
+      |> DateTime.add(3600, :second),:second)
+      |> Kernel.abs() <= 20
+    end
+    test "offsets of plus 15 degrees should adjust sunrise by aprox 1 hour backward" do
+      assert SunTimes.rise(testDate(), 41.00, -70.0+15)
+      |> DateTime.diff(SunTimes.rise(testDate(), 41.00, -70.0)
+      |> DateTime.add(-3600, :second),:second)
+      |> Kernel.abs() <= 20
+    end
+  end
+
+  describe "set/3" do
+    test "offsets of minus 15 degrees should adjust sunset by aprox 1 hour forward" do
+      assert SunTimes.set(testDate(), 41.00, -70.0-15)
+      |> DateTime.diff(SunTimes.set(testDate(), 41.00, -70.0)
+      |> DateTime.add(3600, :second),:second)
+      |> Kernel.abs() <= 20
+    end
+    test "offsets of plus 15 degrees should adjust sunset by aprox 1 hour backward" do
+      assert SunTimes.set(testDate(), 41.00, -70.0+15)
+      |> DateTime.diff(SunTimes.set(testDate(), 41.00, -70.0)
+      |> DateTime.add(-3600, :second),:second)
+      |> Kernel.abs() <= 20
+    end
+  end
+end


### PR DESCRIPTION
Bug fix for edge case where solar event does not occur on the day that the function was called on. The bug fix updates the datetime value when the time is over 24 hours or under 0 in order to return the correct date as well as time.