### PR TITLE
Fix two wrapping bugs leading to incorrect dates

### DIFF
--- a/lib/sun_times.ex
+++ b/lib/sun_times.ex
@@ -82,8 +82,10 @@ defmodule SunTimes do
 
         # UT = T - lngHour
         gmt_hours = local_mean_time - longitude_hour
-        gmt_hours = if gmt_hours > 24, do: gmt_hours - 24.0, else: gmt_hours
-        gmt_hours = if gmt_hours < 0, do: gmt_hours + 24.0, else: gmt_hours
+
+        # If gmt_hours > 24 or < 0 wrap hours and update date
+        {gmt_hours, datetime} = if gmt_hours > 24, do: {gmt_hours - 24.0, next_day(datetime)}, else: {gmt_hours, datetime}
+        {gmt_hours, datetime} = if gmt_hours < 0, do: {gmt_hours + 24.0, prev_day(datetime)}, else: {gmt_hours, datetime}
 
         hour = Float.floor(gmt_hours)
         hour_remainder = (gmt_hours - hour) * 60.0

--- a/lib/sun_times.ex
+++ b/lib/sun_times.ex
@@ -80,6 +80,9 @@ defmodule SunTimes do
         # T = H + RA - (0.06571 * t) - 6.622
         local_mean_time = suns_local_hour_hours + sun_right_ascension_hours - (0.06571 * approximate_time) - 6.622
 
+        # Convert sunset's negative local time to positive number of hours
+        local_mean_time = if event == :set, do: local_mean_time + 24, else: local_mean_time
+
         # UT = T - lngHour
         gmt_hours = local_mean_time - longitude_hour
 

--- a/test/sun_times_test.exs
+++ b/test/sun_times_test.exs
@@ -57,4 +57,20 @@ defmodule SunTimesTest do
              )
     end
   end
+
+  describe "relationship of sunset to sunrise" do
+    test "for all longitudes sunset should be after sunrise" do
+      rise = TestHelpers.loopThroughTimeZones(30, 5, :rise, 0)
+      set = TestHelpers.loopThroughTimeZones(30, 5, :set, 0)
+
+      -12..11
+      |> Enum.each(fn hour ->
+        assert DateTime.diff(
+                 Enum.at(set, hour),
+                 Enum.at(rise, hour),
+                 :second
+               ) >= 0
+      end)
+    end
+  end
 end

--- a/test/sun_times_test.exs
+++ b/test/sun_times_test.exs
@@ -1,0 +1,60 @@
+ExUnit.start()
+
+defmodule SunTimesTest do
+  use ExUnit.Case
+
+  defmodule TestHelpers do
+    def testDate() do
+      DateTime.new!(~D[2022-05-26], ~T[00:00:00], "Etc/UTC")
+    end
+
+    def compareUTCArrays(arr1, arr2, tolerance) do
+      -11..11
+      |> Enum.map(fn hour ->
+        assert abs(
+                 DateTime.diff(
+                   Enum.at(arr1, hour),
+                   Enum.at(arr2, hour),
+                   :second
+                 )
+               ) <= tolerance
+      end)
+    end
+
+    def loopThroughTimeZones(lat, lon, event, offset) do
+      if event == :set do
+        -11..11
+        |> Enum.map(fn hour ->
+          SunTimes.set(testDate(), lat, lon + hour * 15)
+          |> DateTime.add(-offset * 3600, :second)
+        end)
+      else
+        -11..11
+        |> Enum.map(fn hour ->
+          SunTimes.rise(testDate(), lat, lon + hour * 15)
+          |> DateTime.add(-offset * 3600, :second)
+        end)
+      end
+    end
+  end
+
+  describe "rise/3" do
+    test "offsets of +/- 15 degrees should adjust sunrise by aprox 1 hour" do
+      assert TestHelpers.compareUTCArrays(
+               TestHelpers.loopThroughTimeZones(30, -10, :rise, 0),
+               TestHelpers.loopThroughTimeZones(30, 5, :rise, -1),
+               50
+             )
+    end
+  end
+
+  describe "set/3" do
+    test "offsets of +/- 15 degrees should adjust sunset by aprox 1 hour" do
+      assert TestHelpers.compareUTCArrays(
+               TestHelpers.loopThroughTimeZones(30, -10, :set, 0),
+               TestHelpers.loopThroughTimeZones(30, 5, :set, -1),
+               50
+             )
+    end
+  end
+end


### PR DESCRIPTION
Two bug fixes for wrapping errors and tests for these bug fixes. The first one was a bug with gmt/datetime where the date wouldn't change if the time was less than 0 or exceeded 24 hours. The second was a bug with sunset where a negative time would be stored in local_mean_time.